### PR TITLE
Layout for medium devices desktops fixed

### DIFF
--- a/templates/views/block_manager/render/grid.tpl
+++ b/templates/views/block_manager/render/grid.tpl
@@ -9,7 +9,7 @@
 {if $grid.status == "A" && $content}
     {if $grid.alpha}<div class="row">{/if}
         {$width = $fluid_width|default:$grid.width}
-        <section class="col-lg-{$width}{if $grid.offset} col-lg-offset-{$grid.offset}{/if}{if $grid.user_class} {$grid.user_class}{/if}" >
+        <section class="col-md-{$width}{if $grid.offset} col-md-offset-{$grid.offset}{/if}{if $grid.user_class} {$grid.user_class}{/if}">
             {$content nofilter}
         </section>
     {if $grid.omega}</div>{/if}


### PR DESCRIPTION
.col-lg-* classes are used for large devices (>1200px) and layout of medium devices looks like a mobile. This corrects layout.